### PR TITLE
Removing the gray background hover on desktop css.

### DIFF
--- a/library/src/main/resources/webroot/css/color_scheme-github.css
+++ b/library/src/main/resources/webroot/css/color_scheme-github.css
@@ -49,18 +49,15 @@ body.color_scheme-github a.page {
 }
 body.color_scheme-github a.page:hover {
     color: #06c;
-    background: #efefef;
 }
 body.color_scheme-github a.tochead {
     color: black;
 }
 body.color_scheme-github .collap a.tochead:hover {
     color: #06c;
-    background: #efefef;
 }
 body.color_scheme-github a.header-link:hover {
     color: #06c;
-    background: #efefef;
 }
 body.color_scheme-github code.prettyprint span.str {
   color: #dd1144

--- a/library/src/main/resources/webroot/css/color_scheme-redmond.css
+++ b/library/src/main/resources/webroot/css/color_scheme-redmond.css
@@ -32,18 +32,15 @@ a.page {
 }
 a.page:hover {
     color: #06c;
-    background: #efefef;
 }
 a.tochead {
     color: black;
 }
 .collap a.tochead:hover {
     color: #06c;
-    background: #efefef;
 }
 a.header-link:hover {
     color: #06c;
-    background: #efefef;
 }
 code.prettyprint span.str {
   color:#080

--- a/library/src/main/resources/webroot/css/pamflet-grid.css
+++ b/library/src/main/resources/webroot/css/pamflet-grid.css
@@ -82,11 +82,9 @@ a.tochead {
 }
 .collap a.tochead:hover {
     color: #06c;
-    background: #efefef;
 }
 a.header-link:hover {
     color: #06c;
-    background: #efefef;
 }
 h1:hover span.header-link-content:before,
 h2:hover span.header-link-content:before,


### PR DESCRIPTION
There's a minor layout bug where this background is active below the
content as well when the content is short.

Not sure exactly how to fix that without making the layout more
complicated, but also, the more I look at this behavior the more I
think the background hover gray is just ugly and dated, so, buh bye!