### PR TITLE
CachedFileStorage + FencePlugin

### DIFF
--- a/app/src/main/scala/app.scala
+++ b/app/src/main/scala/app.scala
@@ -12,11 +12,11 @@ object Pamflet {
   def main(args: Array[String]) {
     System.exit(run(args))
   }
-  private def storage(dir: File) = CachedFileStorage(dir)
+  private def storage(dir: File, ps: List[FencePlugin]) = CachedFileStorage(dir, ps)
   def run(args: Array[String]) = {
     args match {
       case Array(Dir(input), Dir(output)) =>
-        Produce(storage(input).globalized, output)
+        Produce(storage(input, fencePlugins).globalized, output)
         println("Wrote pamflet to " + output)
         0
       case Array(Dir(dir)) => preview(dir)
@@ -34,8 +34,9 @@ object Pamflet {
         1
     }
   }
+  def fencePlugins: List[FencePlugin] = Nil
   def preview(dir: File): Int = {
-    Preview(storage(dir).globalized).run { server =>
+    Preview(storage(dir, fencePlugins).globalized).run { server =>
       unfiltered.util.Browser.open(
         "http://127.0.0.1:%d/".format(server.portBindings.head.port)
       )

--- a/app/src/main/scala/app.scala
+++ b/app/src/main/scala/app.scala
@@ -37,7 +37,7 @@ object Pamflet {
   def preview(dir: File) = {
     Preview(storage(dir).globalized).run { server =>
       unfiltered.util.Browser.open(
-        "http://127.0.0.1:%d/".format(server.port)
+        "http://127.0.0.1:%d/".format(server.portBindings.head.port)
       )
       println("\nPreviewing `%s`. Press CTRL+C to stop.".format(dir))
     }

--- a/app/src/main/scala/app.scala
+++ b/app/src/main/scala/app.scala
@@ -12,7 +12,7 @@ object Pamflet {
   def main(args: Array[String]) {
     System.exit(run(args))
   }
-  private def storage(dir: File) = FileStorage(dir)
+  private def storage(dir: File) = CachedFileStorage(dir)
   def run(args: Array[String]) = {
     args match {
       case Array(Dir(input), Dir(output)) =>
@@ -34,7 +34,7 @@ object Pamflet {
         1
     }
   }
-  def preview(dir: File) = {
+  def preview(dir: File): Int = {
     Preview(storage(dir).globalized).run { server =>
       unfiltered.util.Browser.open(
         "http://127.0.0.1:%d/".format(server.portBindings.head.port)

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,8 @@ lazy val knockoffDeps = Def.setting { Seq(
 val unfilteredVersion = "0.8.3"
 val stringtemplateVersion = "3.2.1"
 lazy val libraryDeps = Def.setting { Seq(
-  "net.databinder" %% "unfiltered-netty-server" % unfilteredVersion,
+  "net.databinder" %% "unfiltered-filter" % unfilteredVersion,
+  "net.databinder" %% "unfiltered-jetty" % unfilteredVersion,
   "org.antlr" % "stringtemplate" % stringtemplateVersion
 )}
 val launcherInterfaceVersion = "0.13.0"

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 lazy val common = ls.Plugin.lsSettings ++ Seq(
   organization := "net.databinder",
-  version := "0.6.0",
-  scalaVersion := "2.10.3",
-  crossScalaVersions := Seq("2.10.3"),
+  version := "0.7.0-SNAPSHOT",
+  scalaVersion := "2.10.4",
+  crossScalaVersions := Seq("2.11.5", "2.10.4"),
   credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
   homepage :=
     Some(new java.net.URL("http://pamflet.databinder.net/")),
@@ -31,21 +31,21 @@ lazy val common = ls.Plugin.lsSettings ++ Seq(
     </developers>)
 )
 
-val knockoffVersion = "0.8.1"
+val knockoffVersion = "0.8.3"
 lazy val knockoffDeps = Def.setting { Seq(
   "com.tristanhunt" %% "knockoff" % knockoffVersion
 )}
-val unfilteredVersion = "0.7.0"
+val unfilteredVersion = "0.8.3"
 val stringtemplateVersion = "3.2.1"
 lazy val libraryDeps = Def.setting { Seq(
   "net.databinder" %% "unfiltered-netty-server" % unfilteredVersion,
   "org.antlr" % "stringtemplate" % stringtemplateVersion
 )}
 val launcherInterfaceVersion = "0.13.0"
-val servletApiVersion = "2.5"
+val servletApiVersion = "3.0.1"
 lazy val appDeps = Def.setting { Seq(
   "org.scala-sbt" % "launcher-interface" % launcherInterfaceVersion % "provided",
-  "javax.servlet" % "servlet-api" % servletApiVersion
+  "javax.servlet" % "javax.servlet-api" % servletApiVersion
 )}
 
 lazy val pamflet: Project =
@@ -63,7 +63,6 @@ lazy val knockoff: Project =
   settings(
     name := "pamflet-knockoff",
     description := "Extensions to the Knockoff Markdown parser",
-    crossScalaVersions := Seq("2.9.0", "2.9.1", "2.10.3"),
     libraryDependencies ++= knockoffDeps.value
   )
 lazy val library: Project =

--- a/docs/99.markdown
+++ b/docs/99.markdown
@@ -12,5 +12,6 @@ Who's Using Pamflet?
 * [learning Scalaz](http://eed3si9n.com/learning-scalaz/)
 * [tetrix in Scala](http://eed3si9n.com/tetrix-in-scala/)
 * [sbt](http://www.scala-sbt.org/0.13/tutorial/index.html)
+* [scodec](http://scodec.org/guide/)
 
 Are you using Pamflet? Add your project and send a pull request.

--- a/knockoff/src/main/scala/parsers.scala
+++ b/knockoff/src/main/scala/parsers.scala
@@ -5,7 +5,7 @@ import scala.util.parsing.input.{ CharSequenceReader, Position, Reader }
 
 object PamfletDiscounter
   extends Discounter 
-  with FencedDiscounter
+  with MutableFencedDiscounter
   with SmartyDiscounter
   with IdentifiedHeaders
   with Html5Imgs

--- a/library/src/main/resources/webroot/css/color_scheme-github.css
+++ b/library/src/main/resources/webroot/css/color_scheme-github.css
@@ -49,18 +49,15 @@ body.color_scheme-github a.page {
 }
 body.color_scheme-github a.page:hover {
     color: #06c;
-    background: #efefef;
 }
 body.color_scheme-github a.tochead {
     color: black;
 }
 body.color_scheme-github .collap a.tochead:hover {
     color: #06c;
-    background: #efefef;
 }
 body.color_scheme-github a.header-link:hover {
     color: #06c;
-    background: #efefef;
 }
 body.color_scheme-github code.prettyprint span.str {
   color: #dd1144

--- a/library/src/main/resources/webroot/css/color_scheme-redmond.css
+++ b/library/src/main/resources/webroot/css/color_scheme-redmond.css
@@ -32,18 +32,15 @@ a.page {
 }
 a.page:hover {
     color: #06c;
-    background: #efefef;
 }
 a.tochead {
     color: black;
 }
 .collap a.tochead:hover {
     color: #06c;
-    background: #efefef;
 }
 a.header-link:hover {
     color: #06c;
-    background: #efefef;
 }
 code.prettyprint span.str {
   color:#080

--- a/library/src/main/resources/webroot/css/pamflet-grid.css
+++ b/library/src/main/resources/webroot/css/pamflet-grid.css
@@ -82,11 +82,9 @@ a.tochead {
 }
 .collap a.tochead:hover {
     color: #06c;
-    background: #efefef;
 }
 a.header-link:hover {
     color: #06c;
-    background: #efefef;
 }
 h1:hover span.header-link-content:before,
 h2:hover span.header-link-content:before,

--- a/library/src/main/scala/contents.scala
+++ b/library/src/main/scala/contents.scala
@@ -52,8 +52,9 @@ sealed trait Page {
 }
 sealed trait AuthoredPage extends Page {
   def blocks: Seq[Block]
+  // Always reference Scala for fenced plugin purpose
   lazy val referencedLangs =
-    (Set.empty[String] /: blocks) {
+    (Set("scala") /: blocks) {
       case (s, FencedCodeBlock(_, _, Some(lang))) => s + lang
       case (s, _) => s
     }

--- a/library/src/main/scala/knock.scala
+++ b/library/src/main/scala/knock.scala
@@ -5,18 +5,17 @@ import com.tristanhunt.knockoff._
 import collection.immutable.Map
 
 object Knock {
-  def knockEither(value: String, propFiles: Seq[File]): Either[Throwable, (String, Seq[Block], Template)] = {
-    val frontin = Frontin(value)
-    val template = StringTemplate(propFiles, frontin header, Map())
-    val raw = template(frontin body)
-    try {
-      Right((raw.toString, PamfletDiscounter.knockoff(raw), template))
-    } catch {
-      case e: Throwable => Left(e)
-    }
-  }
+  lazy val discounter = PamfletDiscounter
+  def notifyBeginLanguage(): Unit = discounter.notifyBeginLanguage()
+  def notifyBeginPage(): Unit = discounter.notifyBeginPage()
 
-  def knockEither(value: String, template0: Template): Either[Throwable, (String, Seq[Block], Template)] = {
+  def knockEither(value: String, propFiles: Seq[File], ps: List[FencePlugin]): Either[Throwable, (String, Seq[Block], Template)] = 
+    knockEither(value, StringTemplate(propFiles, None, Map()), ps)
+
+  def knockEither(value: String, template0: Template): Either[Throwable, (String, Seq[Block], Template)] =
+    knockEither(value, template0, List())
+
+  def knockEither(value: String, template0: Template, ps: List[FencePlugin]): Either[Throwable, (String, Seq[Block], Template)] = {
     val frontin = Frontin(value)
     val template = frontin.header match {
       case None    => template0
@@ -24,7 +23,7 @@ object Knock {
     }
     val raw = template(frontin body)
     try {
-      Right((raw.toString, PamfletDiscounter.knockoff(raw), template))
+      Right((raw.toString, discounter.knockoffWithPlugins(raw, ps), template))
     } catch {
       case e: Throwable => Left(e)
     }

--- a/library/src/main/scala/printer.scala
+++ b/library/src/main/scala/printer.scala
@@ -1,5 +1,5 @@
 package pamflet
-import PamfletDiscounter.toXHTML
+import Knock.discounter.toXHTML
 import collection.immutable.Map
 
 object Printer {
@@ -160,6 +160,7 @@ case class Printer(contents: Contents, globalized: Globalized, manifest: Option[
       case Right(x) => x
       case Left(x)  =>
         Console.err.println("Error while processing " + x)
+        // x.printStackTrace()
         throw x
     }
     toXHTML(blocks)    

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.2
+sbt.version=0.13.7


### PR DESCRIPTION
## CachedFileStorage

This uses `lastModified` of all files to cache `FileStorage` instance. Preview should get much faster on larger pamflets.

## FencePlugin

FencePlugin is a way of processing fenced code block to make it do some interesting things.
For example this can be used to integrate with sbt to run 

    ```console
    scala> 1 + 1
    ```

To render

```scala
scala> 1 + 1
res0: Int = 2
```

The implementation for `console` fence and `compile` fence is available here - https://github.com/sbt/sbt-pamflet
